### PR TITLE
Fix Anthropic model naming

### DIFF
--- a/src/lib/cl_llms.py
+++ b/src/lib/cl_llms.py
@@ -10,8 +10,8 @@ def get_chat_profiles():
             icon="https://picsum.photos/200",
         ),
         cl.ChatProfile(
-            name="Antrophic",
-            markdown_description="Antrophic GPT",
+            name="Anthropic",
+            markdown_description="Anthropic GPT",
             icon="https://picsum.photos/250",
         ),
         cl.ChatProfile(

--- a/src/lib/rag.py
+++ b/src/lib/rag.py
@@ -34,7 +34,7 @@ from pydantic import BaseModel, Field
 
 from lib.core import ChatSettings
 
-LLMS = Enum("LLMS", ["OPENAI", "ANTROPHIC", "OLLAMA"])
+LLMS = Enum("LLMS", ["OPENAI", "ANTHROPIC", "OLLAMA"])
 EMBEDDINGS = Enum("EMBEDDINGS", ["openai", "huggingface"])
 
 class UptatableChatHistory(BaseChatMessageHistory, BaseModel):
@@ -76,7 +76,7 @@ class Rag:
         self.output_formatter = output_formatter
         self.llm_functions = {
             LLMS.OPENAI: ChatOpenAI,
-            LLMS.ANTROPHIC: ChatAnthropic,
+            LLMS.ANTHROPIC: ChatAnthropic,
             LLMS.OLLAMA: ChatOllama,
         }
         self.contextualize_prompt = contextualize_prompt or (


### PR DESCRIPTION
## Summary
- correct Anthropic provider naming in chat profiles
- update RAG enum and mapping to use Anthropic

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689522024008832ea7f2ad71df78f10f